### PR TITLE
Revert "dependabot: [security] bump puma from 3.12.3 to 3.12.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,7 +275,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.1.1)
-    puma (3.12.4)
+    puma (3.12.3)
     puma-rails (0.0.2)
       puma
       rack


### PR DESCRIPTION
Reverts osm-extender/osm-extender#204