### PR TITLE
Revert "dependabot: [security] bump nokogiri from 1.10.5 to 1.10.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
     necromancer (0.4.0)
     netrc (0.11.0)
     nio4r (2.4.0)
-    nokogiri (1.10.8)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     normalize-rails (4.1.1)
     oauth (0.5.4)


### PR DESCRIPTION
Reverts osm-extender/osm-extender#202